### PR TITLE
Update the syntax to pass 'false' to --fail flag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,7 +65,7 @@ Run the program with `link-verifier` from anywhere in the file system.
 **Example**:
 
 ```
-link-verifier --dirs data,content --include *.html,*.yml --fail false
+link-verifier --dirs data,content --include *.html,*.yml --fail=false
 ```
 
 == Usage on CI


### PR DESCRIPTION
Fixes: https://github.com/bmuschko/link-verifier/issues/3

Signed-off-by: Jayesh Kumar <k8s.cncf@gmail.com>